### PR TITLE
Chado tools: add missing jq dep

### DIFF
--- a/tools/chado/macros.xml
+++ b/tools/chado/macros.xml
@@ -3,6 +3,7 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="2.1.2">python-chado</requirement>
+            <requirement type="package" version="1.5">jq</requirement>
             <yield/>
         </requirements>
     </xml>


### PR DESCRIPTION
Just adding the missing requirement for most of the chado tools