### PR TITLE
Fix options for organism_add_organism.xml

### DIFF
--- a/tools/apollo/json2iframe.xml
+++ b/tools/apollo/json2iframe.xml
@@ -20,7 +20,7 @@ python $__tool_directory__/json2iframe.py
   <tests>
       <test>
           <param name="json_file" value="fake.json"/>
-          <output name="html">
+          <output name="output">
               <assert_contents>
                   <has_text text="Embedded Apollo Access" />
               </assert_contents>

--- a/tools/apollo/webapollo.py
+++ b/tools/apollo/webapollo.py
@@ -1544,10 +1544,7 @@ def accessible_organisms(user, orgs):
     permissionMap = {
         x['organism']: x['permissions']
         for x in user.organismPermissions
-        if 'WRITE' in x['permissions'] or
-        'READ' in x['permissions'] or
-        'ADMINISTRATE' in x['permissions'] or
-        user.role == 'ADMIN'
+        if 'WRITE' in x['permissions'] or 'READ' in x['permissions'] or 'ADMINISTRATE' in x['permissions'] or user.role == 'ADMIN'
     }
 
     if 'error' in orgs:

--- a/tools/tripal/organism_add_organism.xml
+++ b/tools/tripal/organism_add_organism.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="organism_add_organism" profile="16.04" name="Create an organism" version="@WRAPPER_VERSION@.0">
+<tool id="organism_add_organism" profile="16.04" name="Create an organism" version="@WRAPPER_VERSION@.1">
     <description>in Tripal</description>
     <macros>
         <import>macros.xml</import>
@@ -25,8 +25,8 @@
 
             '$genus'
             '$species'
-            '$common'
-            '$abbr'
+            --common '$common'
+            --abbr '$abbr'
 
             | jq -S . > $results
     ]]></command>

--- a/tools/tripal/organism_add_organism.xml
+++ b/tools/tripal/organism_add_organism.xml
@@ -92,7 +92,6 @@
             <param name="abbr" value="test" />
             <param name="common" value="test stuff" />
             <param name="common" value="My cool new test organism" />
-
             <expand macro="test_result" />
         </test>
         <test expect_failure="true">
@@ -106,7 +105,6 @@
                 <param name="rank" value="subspecies" />
                 <param name="name" value="strain3" />
             </conditional>
-
             <expand macro="test_result" />
         </test>
     </tests>

--- a/tools/tripal/organism_add_organism.xml
+++ b/tools/tripal/organism_add_organism.xml
@@ -23,10 +23,10 @@
                 --infraspecific_name '$infra.name'
             #end if
 
-            '$genus'
-            '$species'
             --common '$common'
             --abbr '$abbr'
+            '$genus'
+            '$species'
 
             | jq -S . > $results
     ]]></command>


### PR DESCRIPTION
fix https://github.com/galaxy-genome-annotation/galaxy-tools/issues/26
and styling changes to pass linting test on webapollo.py 
and fix test output name on json2iframe.xml to pass travis test (I don't know why the apollo tools where checked in travis whereas I modified only the tripal tools..)