### PR TITLE
Chado: update to 2.3.0, blast interpro loading

### DIFF
--- a/tools/chado/analysis_add_analysis.xml
+++ b/tools/chado/analysis_add_analysis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="analysis_add_analysis" name="Chado analysis add" version="@WRAPPER_VERSION@.2">
+<tool id="analysis_add_analysis" name="Chado analysis add" version="@WRAPPER_VERSION@">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tools/chado/analysis_delete_analyses.xml
+++ b/tools/chado/analysis_delete_analyses.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="analysis_delete_analyses" name="Chado analysis delete" version="@WRAPPER_VERSION@.1">
+<tool id="analysis_delete_analyses" name="Chado analysis delete" version="@WRAPPER_VERSION@">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tools/chado/analysis_get_analyses.xml
+++ b/tools/chado/analysis_get_analyses.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="analysis_get_analyses" name="Chado analysis get" version="@WRAPPER_VERSION@.1">
+<tool id="analysis_get_analyses" name="Chado analysis get" version="@WRAPPER_VERSION@">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tools/chado/chado.py
+++ b/tools/chado/chado.py
@@ -389,7 +389,8 @@ def _get_instance():
         os.environ['GALAXY_CHADO_DBPASS'],
         os.environ['GALAXY_CHADO_DBSCHEMA'],
         os.environ['GALAXY_CHADO_DBPORT'],
-        no_reflect=True
+        no_reflect=True,
+        pool_connections=False
     )
 
 

--- a/tools/chado/chado.py
+++ b/tools/chado/chado.py
@@ -475,3 +475,43 @@ def _list_analyses(ci, *args, **kwargs):
     for an in ci.analysis.get_analyses():
         ans_data.append((an['name'], str(an['analysis_id']), False))
     return ans_data
+
+
+def list_dbs(*args, **kwargs):
+
+    ci = _get_instance()
+
+    # Key for cached data
+    cacheKey = 'dbs'
+    # We don't want to trust "if key in cache" because between asking and fetch
+    # it might through key error.
+    if cacheKey not in cache:
+        # However if it ISN'T there, we know we're safe to fetch + put in
+        # there.<?xml version="1.0"?>
+
+        data = _list_dbs(ci, *args, **kwargs)
+        cache[cacheKey] = data
+        ci.session.close()
+        return data
+    try:
+        # The cache key may or may not be in the cache at this point, it
+        # /likely/ is. However we take no chances that it wasn't evicted between
+        # when we checked above and now, so we reference the object from the
+        # cache in preparation to return.
+        data = cache[cacheKey]
+        ci.session.close()
+        return data
+    except KeyError:
+        # If access fails due to eviction, we will fail over and can ensure that
+        # data is inserted.
+        data = _list_dbs(ci, *args, **kwargs)
+        cache[cacheKey] = data
+        ci.session.close()
+        return data
+
+
+def _list_dbs(ci, *args, **kwargs):
+    dbs_data = []
+    for db in ci.load._get_dbs():
+        dbs_data.append((db['name'], str(db['db_id']), False))
+    return dbs_data

--- a/tools/chado/export_export_fasta.xml
+++ b/tools/chado/export_export_fasta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="export_export_fasta" name="Chado export fasta" version="@WRAPPER_VERSION@.1">
+<tool id="export_export_fasta" name="Chado export fasta" version="@WRAPPER_VERSION@">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tools/chado/export_export_gbk.xml
+++ b/tools/chado/export_export_gbk.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="export_export_gbk" name="Chado export gbk" version="@WRAPPER_VERSION@.1">
+<tool id="export_export_gbk" name="Chado export gbk" version="@WRAPPER_VERSION@">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tools/chado/export_export_gff3.xml
+++ b/tools/chado/export_export_gff3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="export_export_gff3" name="Chado export gff3" version="@WRAPPER_VERSION@.1">
+<tool id="export_export_gff3" name="Chado export gff3" version="@WRAPPER_VERSION@">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tools/chado/expression_add_biomaterial.xml
+++ b/tools/chado/expression_add_biomaterial.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="expression_add_biomaterial" name="Chado biomaterial add" version="@WRAPPER_VERSION@.1">
+<tool id="expression_add_biomaterial" name="Chado biomaterial add" version="@WRAPPER_VERSION@">
     <description></description>
 	<macros>
 		<import>macros.xml</import>

--- a/tools/chado/expression_add_expression.xml
+++ b/tools/chado/expression_add_expression.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="expression_add_expression" name="Chado expression add" version="@WRAPPER_VERSION@.1">
+<tool id="expression_add_expression" name="Chado expression add" version="@WRAPPER_VERSION@">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tools/chado/expression_add_expression.xml
+++ b/tools/chado/expression_add_expression.xml
@@ -14,6 +14,20 @@ chakin expression add_expression
 '$analysis_id'
 '$file_path'
 
+#if $unit:
+  --unit '$unit'
+#end if
+
+--query_type '$query_type'
+
+$match_on_name
+
+#if $re_name:
+  --re_name '$re_name'
+#end if
+
+$skip_missing
+
  > '$results'
 
 @ZIP_PSQL@
@@ -24,6 +38,18 @@ chakin expression add_expression
         <param argument="organism_id" type="select" dynamic_options="list_organisms()" label="Organism" />
         <param argument="analysis_id" type="select" dynamic_options="list_analyses()"  label="Analysis" />
         <param name="file_path" label="Expression matrix" argument="file_path" type="data" format="tabular" help="Tabular file where columns are experimental conditions, and rows are features" />
+
+	      <param name="unit" label="Unit" argument="--unit" type="text" help="The units associated with the loaded values (ie, FPKM, RPKM, raw counts)" />
+
+        <param name="query_type" label="Query type" argument="--query_type" type="text" help="The feature type (e.g. 'gene', 'mRNA', 'polypeptide', 'contig') of the query. It must be a valid Sequence Ontology term." value="mRNA" />
+
+        <param name="match_on_name" label="Match On Name" argument="--match_on_name" type="boolean" truevalue="--match_on_name" falsevalue="" help="Match features using their name instead of their uniquename" />
+
+        <param name="re_name" label="Name regular expression" argument="--re_name" type="text" help="Regular expression to extract the feature name from the input file (first capturing group will be used)." optional="true">
+            <expand macro="sanitized"/>
+        </param>
+
+        <param name="skip_missing" label="Skip Missing" argument="--skip_missing" type="boolean" truevalue="--skip_missing" falsevalue="" help="Skip lines with unknown features instead of aborting everything." />
 
         <expand macro="wait_for"/>
     </inputs>

--- a/tools/chado/expression_delete_all_biomaterials.xml
+++ b/tools/chado/expression_delete_all_biomaterials.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="expression_delete_all_biomaterials" name="Chado biomaterials delete all" version="@WRAPPER_VERSION@.1">
+<tool id="expression_delete_all_biomaterials" name="Chado biomaterials delete all" version="@WRAPPER_VERSION@">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tools/chado/expression_delete_biomaterials.xml
+++ b/tools/chado/expression_delete_biomaterials.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="expression_delete_biomaterials" name="Chado biomaterials delete" version="@WRAPPER_VERSION@.1">
+<tool id="expression_delete_biomaterials" name="Chado biomaterials delete" version="@WRAPPER_VERSION@">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tools/chado/expression_get_biomaterials.xml
+++ b/tools/chado/expression_get_biomaterials.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="expression_get_biomaterials" name="Chado biomaterial get" version="@WRAPPER_VERSION@.1">
+<tool id="expression_get_biomaterials" name="Chado biomaterial get" version="@WRAPPER_VERSION@">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tools/chado/feature_delete_features.xml
+++ b/tools/chado/feature_delete_features.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="feature_delete_features" name="Chado features delete" version="@WRAPPER_VERSION@.1">
+<tool id="feature_delete_features" name="Chado features delete" version="@WRAPPER_VERSION@">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tools/chado/feature_delete_features.xml
+++ b/tools/chado/feature_delete_features.xml
@@ -11,8 +11,8 @@
 
 chakin feature delete_features
 
-#if $organism:
-  --organism_id '$organism'
+#if $organism_id:
+  --organism_id '$organism_id'
 #end if
 #if $analysis_id:
   --analysis_id '$analysis_id'
@@ -31,7 +31,7 @@ chakin feature delete_features
     <inputs>
         <expand macro="psql_target"/>
         <!-- options -->
-        <param argument="--organism" type="select" dynamic_options="list_organisms()" label="Organism" />
+        <param argument="--organism_id" type="select" dynamic_options="list_organisms()" label="Organism" />
         <param argument="--analysis_id" type="select" dynamic_options="list_analyses()" label="Analysis" />
         <param name="name" label="Name" argument="--name" type="text" help="name filter" />
         <param name="uniquename" label="Uniquename" argument="--uniquename" type="text" help="uniquename filter" />

--- a/tools/chado/feature_get_features.xml
+++ b/tools/chado/feature_get_features.xml
@@ -11,8 +11,8 @@
 
 chakin feature get_features
 
-#if $organism:
-  --organism_id '$organism'
+#if $organism_id:
+  --organism_id '$organism_id'
 #end if
 #if $analysis_id:
   --analysis_id '$analysis_id'
@@ -31,7 +31,7 @@ chakin feature get_features
     <inputs>
         <expand macro="psql_target"/>
         <!-- options -->
-        <param argument="--organism" type="select" dynamic_options="list_organisms()" label="Organism" />
+        <param argument="--organism_id" type="select" dynamic_options="list_organisms()" label="Organism" />
         <param argument="--analysis_id" type="select" dynamic_options="list_analyses()" label="Analysis" />
         <param name="name" label="Name" argument="--name" type="text" help="name filter" />
         <param name="uniquename" label="Uniquename" argument="--uniquename" type="text" help="uniquename filter" />

--- a/tools/chado/feature_get_features.xml
+++ b/tools/chado/feature_get_features.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="feature_get_features" name="Chado features get" version="@WRAPPER_VERSION@.1">
+<tool id="feature_get_features" name="Chado features get" version="@WRAPPER_VERSION@">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tools/chado/feature_load_fasta.xml
+++ b/tools/chado/feature_load_fasta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="feature_load_fasta" name="Chado load fasta" version="@WRAPPER_VERSION@.1">
+<tool id="feature_load_fasta" name="Chado load fasta" version="@WRAPPER_VERSION@">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tools/chado/feature_load_featureprops.xml
+++ b/tools/chado/feature_load_featureprops.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="feature_load_featureprops" name="Chado load feature properties" version="@WRAPPER_VERSION@.1">
+<tool id="feature_load_featureprops" name="Chado load feature properties" version="@WRAPPER_VERSION@">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tools/chado/feature_load_gff.xml
+++ b/tools/chado/feature_load_gff.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="feature_load_gff" name="Chado load gff" version="@WRAPPER_VERSION@.1">
+<tool id="feature_load_gff" name="Chado load gff" version="@WRAPPER_VERSION@">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tools/chado/feature_load_go.xml
+++ b/tools/chado/feature_load_go.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="feature_load_go" name="Chado load GO annotation" version="@WRAPPER_VERSION@.1">
+<tool id="feature_load_go" name="Chado load GO annotation" version="@WRAPPER_VERSION@">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tools/chado/load_blast.xml
+++ b/tools/chado/load_blast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<tool id="feature_load_go" name="Chado load GO annotation" version="@WRAPPER_VERSION@">
-    <description></description>
+<tool id="load_blast" name="Chado load Blast results" version="@WRAPPER_VERSION@.0">
+ <description></description>
     <macros>
         <import>macros.xml</import>
     </macros>
@@ -9,17 +9,16 @@
     <command detect_errors="aggressive"><![CDATA[
 @START_PSQL@ &&
 
-chakin load go
-'$input'
-'$organism_id'
+chakin load blast
 '$analysis_id'
+'$organism_id'
+'$input'
+
+--blastdb_id '$blastdb_id'
 
 --query_type '$query_type'
 
 $match_on_name
-
---name_column '$name_column'
---go_column '$go_column'
 
 #if $re_name:
   --re_name '$re_name'
@@ -27,14 +26,14 @@ $match_on_name
 
 $skip_missing
 
- > '$results'
+| jq -S . > $results
 
 @ZIP_PSQL@
     ]]></command>
     <inputs>
         <expand macro="psql_target"/>
         <!-- arguments -->
-        <param name="input" label="GO annotation" argument="input" type="data" format="tabular" help="Path to the GO annotation file to load" />
+        <param name="input" label="Blast results" argument="input" type="data" format="xml" help="Path to the Blast XML file to load" />
         <param argument="analysis_id" type="select" dynamic_options="list_analyses()"  label="Analysis" />
         <param argument="organism_id" type="select" dynamic_options="list_organisms()" label="Organism" />
 
@@ -43,26 +42,24 @@ $skip_missing
 
         <param name="match_on_name" label="Match On Name" argument="--match_on_name" type="boolean" truevalue="--match_on_name" falsevalue="" help="Match features using their name instead of their uniquename" />
 
-        <param name="name_column" label="Identifier column" argument="--name_column" type="integer" value="2" help="Column containing the feature identifiers." />
-
-        <param name="go_column" label="GO column" argument="--go_column" type="integer" value="5" help="Column containing the GO id." />
+        <param argument="blastdb_id" type="select" dynamic_options="list_dbs()" label="Database blasted against" />
 
         <param name="re_name" label="Name regular expression" argument="--re_name" type="text" help="Regular expression to extract the feature name from the input file (first capturing group will be used)." optional="true">
             <expand macro="sanitized"/>
         </param>
 
-        <param name="skip_missing" label="Skip Missing" argument="--skip_missing" type="boolean" truevalue="--skip_missing" falsevalue="" help="Skip lines with unknown features or GO id instead of aborting everything." />
+        <param name="skip_missing" label="Skip Missing" argument="--skip_missing" type="boolean" truevalue="--skip_missing" falsevalue="" help="Skip lines with unknown features instead of aborting everything." />
 
         <expand macro="wait_for"/>
     </inputs>
     <outputs>
-        <data format="txt" name="results"/>
+        <data format="json" name="results"/>
         <data format="postgresql" name="outfile" from_work_dir="postgresql_out.tar.bz2" label="${tool.name} on ${on_string}">
-    			<filter>psql_target['method'] == "pgtools"</filter>
-    		</data>
+            <filter>psql_target['method'] == "pgtools"</filter>
+        </data>
     </outputs>
     <help>
-Load GO annotation from a tabular file
+Load a blast analysis, in the same way as does the tripal_analysis_blast module
 
 @HELP@
     </help>

--- a/tools/chado/load_interpro.xml
+++ b/tools/chado/load_interpro.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<tool id="feature_load_go" name="Chado load GO annotation" version="@WRAPPER_VERSION@">
-    <description></description>
+<tool id="load_interpro" name="Chado load InterProScan results" version="@WRAPPER_VERSION@.0">
+ <description>interpro</description>
     <macros>
         <import>macros.xml</import>
     </macros>
@@ -9,17 +9,16 @@
     <command detect_errors="aggressive"><![CDATA[
 @START_PSQL@ &&
 
-chakin load go
-'$input'
-'$organism_id'
+chakin load interpro
 '$analysis_id'
+'$organism_id'
+'$input'
+
+$parse_go
 
 --query_type '$query_type'
 
 $match_on_name
-
---name_column '$name_column'
---go_column '$go_column'
 
 #if $re_name:
   --re_name '$re_name'
@@ -27,14 +26,14 @@ $match_on_name
 
 $skip_missing
 
- > '$results'
+| jq -S . > $results
 
 @ZIP_PSQL@
     ]]></command>
     <inputs>
         <expand macro="psql_target"/>
         <!-- arguments -->
-        <param name="input" label="GO annotation" argument="input" type="data" format="tabular" help="Path to the GO annotation file to load" />
+        <param name="input" label="InterProScan results" argument="input" type="data" format="xml" help="Path to the InterProScan XML file to load" />
         <param argument="analysis_id" type="select" dynamic_options="list_analyses()"  label="Analysis" />
         <param argument="organism_id" type="select" dynamic_options="list_organisms()" label="Organism" />
 
@@ -43,26 +42,24 @@ $skip_missing
 
         <param name="match_on_name" label="Match On Name" argument="--match_on_name" type="boolean" truevalue="--match_on_name" falsevalue="" help="Match features using their name instead of their uniquename" />
 
-        <param name="name_column" label="Identifier column" argument="--name_column" type="integer" value="2" help="Column containing the feature identifiers." />
-
-        <param name="go_column" label="GO column" argument="--go_column" type="integer" value="5" help="Column containing the GO id." />
+        <param name="parse_go" label="Parse Go" argument="parse_go" type="boolean" truevalue="--parse_go" falsevalue="" help="Load GO annotation to the database" />
 
         <param name="re_name" label="Name regular expression" argument="--re_name" type="text" help="Regular expression to extract the feature name from the input file (first capturing group will be used)." optional="true">
             <expand macro="sanitized"/>
         </param>
 
-        <param name="skip_missing" label="Skip Missing" argument="--skip_missing" type="boolean" truevalue="--skip_missing" falsevalue="" help="Skip lines with unknown features or GO id instead of aborting everything." />
+        <param name="skip_missing" label="Skip Missing" argument="--skip_missing" type="boolean" truevalue="--skip_missing" falsevalue="" help="Skip lines with unknown features instead of aborting everything." />
 
         <expand macro="wait_for"/>
     </inputs>
     <outputs>
-        <data format="txt" name="results"/>
+        <data format="json" name="results"/>
         <data format="postgresql" name="outfile" from_work_dir="postgresql_out.tar.bz2" label="${tool.name} on ${on_string}">
-    			<filter>psql_target['method'] == "pgtools"</filter>
-    		</data>
+            <filter>psql_target['method'] == "pgtools"</filter>
+        </data>
     </outputs>
     <help>
-Load GO annotation from a tabular file
+Load an InterProScan analysis, in the same way as does the tripal_analysis_intepro module
 
 @HELP@
     </help>

--- a/tools/chado/macros.xml
+++ b/tools/chado/macros.xml
@@ -2,7 +2,7 @@
 <macros>
     <xml name="requirements">
         <requirements>
-            <requirement type="package" version="2.2.6">python-chado</requirement>
+            <requirement type="package" version="@LIB_VERSION@">python-chado</requirement>
             <requirement type="package" version="1.5">jq</requirement>
             <requirement type="package" version="@PG_VERSION@">postgresql</requirement>
             <requirement type="package" version="0.1">pglite</requirement>
@@ -10,6 +10,8 @@
         </requirements>
     </xml>
 
+    <token name="@LIB_VERSION@">2.3.0</token>
+    <token name="@WRAPPER_VERSION@">@LIB_VERSION@</token>
     <token name="@PG_VERSION@">11.2</token>
 
     <xml name="stdio">
@@ -19,8 +21,6 @@
             <exit_code range="1:" />
         </stdio>
     </xml>
-
-    <token name="@WRAPPER_VERSION@">2.2.6</token>
 
     <xml name="citation">
         <citations>

--- a/tools/chado/macros.xml
+++ b/tools/chado/macros.xml
@@ -10,7 +10,7 @@
         </requirements>
     </xml>
 
-    <token name="@LIB_VERSION@">2.2.6</token>
+    <token name="@LIB_VERSION@">2.3.0</token>
     <token name="@WRAPPER_VERSION@">@LIB_VERSION@</token>
     <token name="@PG_VERSION@">11.2</token>
 

--- a/tools/chado/macros.xml
+++ b/tools/chado/macros.xml
@@ -10,7 +10,7 @@
         </requirements>
     </xml>
 
-    <token name="@LIB_VERSION@">2.3.0</token>
+    <token name="@LIB_VERSION@">2.2.6</token>
     <token name="@WRAPPER_VERSION@">@LIB_VERSION@</token>
     <token name="@PG_VERSION@">11.2</token>
 

--- a/tools/chado/organism_add_organism.xml
+++ b/tools/chado/organism_add_organism.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="organism_add_organism" name="Chado organism add" version="@WRAPPER_VERSION@.2">
+<tool id="organism_add_organism" name="Chado organism add" version="@WRAPPER_VERSION@">
     <description></description>
 	<macros>
 		<import>macros.xml</import>

--- a/tools/chado/organism_delete_all_organisms.xml
+++ b/tools/chado/organism_delete_all_organisms.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="organism_delete_all_organisms" name="Chado delete all organisms" version="@WRAPPER_VERSION@.2">
+<tool id="organism_delete_all_organisms" name="Chado delete all organisms" version="@WRAPPER_VERSION@">
     <description></description>
 	<macros>
 		<import>macros.xml</import>

--- a/tools/chado/organism_delete_organism.xml
+++ b/tools/chado/organism_delete_organism.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="organism_delete_organisms" name="Chado organism delete" version="@WRAPPER_VERSION@.0">
+<tool id="organism_delete_organisms" name="Chado organism delete" version="@WRAPPER_VERSION@">
     <description></description>
 	<macros>
 		<import>macros.xml</import>

--- a/tools/chado/organism_get_organisms.xml
+++ b/tools/chado/organism_get_organisms.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="organism_get_organisms" name="Chado organism get" version="@WRAPPER_VERSION@.1">
+<tool id="organism_get_organisms" name="Chado organism get" version="@WRAPPER_VERSION@">
     <description></description>
 	<macros>
 		<import>macros.xml</import>

--- a/tools/chado/phylogeny_gene_families.xml
+++ b/tools/chado/phylogeny_gene_families.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="phylogeny_gene_families" name="Chado refresh gene families" version="@WRAPPER_VERSION@.1">
+<tool id="phylogeny_gene_families" name="Chado refresh gene families" version="@WRAPPER_VERSION@">
     <description>for phylogeny module</description>
 	<macros>
 		<import>macros.xml</import>

--- a/tools/chado/phylogeny_gene_order.xml
+++ b/tools/chado/phylogeny_gene_order.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="phylogeny_gene_order" name="Chado gene ordering" version="@WRAPPER_VERSION@.1">
+<tool id="phylogeny_gene_order" name="Chado gene ordering" version="@WRAPPER_VERSION@">
  	<description>for phylogeny module</description>
 	<macros>
 		<import>macros.xml</import>

--- a/tools/chado/phylogeny_load_tree.xml
+++ b/tools/chado/phylogeny_load_tree.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="phylogeny_load_tree" name="Chado load trees" version="@WRAPPER_VERSION@.2">
+<tool id="phylogeny_load_tree" name="Chado load trees" version="@WRAPPER_VERSION@">
     <description>for phylogeny module</description>
 	<macros>
 		<import>macros.xml</import>


### PR DESCRIPTION
So here's an update to the chado tools to python-chado 2.3.0 with these changes :
- added blast and interproscan loaders
- added new options to expression data loader
- really fixed #23 this time (previous fix was not working)