### PR TITLE
Apollo: update to python-apollo 4.2.1 (fixes group permission)

### DIFF
--- a/tools/apollo/create_or_update_organism.xml
+++ b/tools/apollo/create_or_update_organism.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="create_or_update" name="Create or Update Organism" version="@WRAPPER_VERSION@+galaxy1">
+<tool id="create_or_update" name="Create or Update Organism" version="@WRAPPER_VERSION@">
   <description>will create the organism if it doesn't exist, and update otherwise</description>
   <macros>
     <import>macros.xml</import>

--- a/tools/apollo/macros.xml
+++ b/tools/apollo/macros.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <macros>
-  <token name="@WRAPPER_VERSION@">4.1</token>
+  <token name="@WRAPPER_VERSION@">4.2.1</token>
 
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="4.1">apollo</requirement>
+      <requirement type="package" version="4.2.1">apollo</requirement>
       <yield/>
     </requirements>
   </xml>


### PR DESCRIPTION
A little update to fix the group option in create or update organism tool
https://github.com/galaxy-genome-annotation/python-apollo/pull/27