### PR TITLE
python-chado: update to 2.3.5

### DIFF
--- a/tools/chado/macros.xml
+++ b/tools/chado/macros.xml
@@ -10,7 +10,7 @@
         </requirements>
     </xml>
 
-    <token name="@LIB_VERSION@">2.3.4</token>
+    <token name="@LIB_VERSION@">2.3.5</token>
     <token name="@WRAPPER_VERSION@">@LIB_VERSION@+galaxy0</token>
     <token name="@PG_VERSION@">11.2</token>
 


### PR DESCRIPTION
A minor update to fix errors with recent sqlalchemy release