### PR TITLE
python-chado: update to 2.3.6

### DIFF
--- a/tools/chado/macros.xml
+++ b/tools/chado/macros.xml
@@ -10,7 +10,7 @@
         </requirements>
     </xml>
 
-    <token name="@LIB_VERSION@">2.3.5</token>
+    <token name="@LIB_VERSION@">2.3.6</token>
     <token name="@WRAPPER_VERSION@">@LIB_VERSION@+galaxy0</token>
     <token name="@PG_VERSION@">11.2</token>
 


### PR DESCRIPTION
Just a tiny bugfix release for the gff loader